### PR TITLE
Hotfix/binary path v3.2.1

### DIFF
--- a/dkron/Chart.yaml
+++ b/dkron/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.2
+version: 2.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/dkron/templates/agent-deployment.yaml
+++ b/dkron/templates/agent-deployment.yaml
@@ -40,7 +40,7 @@ spec:
             {{- toYaml .Values.agent.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./dkron"]
+          command: ["/usr/local/bin/dkron"]
           args:
               - "agent"
               - "--config=/etc/dkron/dkron.yaml"

--- a/dkron/templates/server-pdr.yaml
+++ b/dkron/templates/server-pdr.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "dkron.fullname" . }}

--- a/dkron/templates/server-statefulSet.yaml
+++ b/dkron/templates/server-statefulSet.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.server.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["./dkron"]
+          command: ["/usr/local/bin/dkron"]
           args:
             - "agent"
             - "--server"

--- a/dkron/values.yaml
+++ b/dkron/values.yaml
@@ -45,7 +45,7 @@ server:
 
   service:
     type: ClusterIP
-    port: 80
+    port: 8080
 
   resources:
     {}


### PR DESCRIPTION
Fixed issues/warnings below:

- Error: failed to start container "dkron": Error response from daemon: OCI runtime create failed: container_linux.go:380: starting container process caused: exec: "./dkron": stat ./dkron: no such file or directory: unknown
- Error: pod dkron-test-connection failed
- policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget