### PR TITLE
Add readiness probe & set podManagementPolicy: Parallel & change service configuration

### DIFF
--- a/dkron/templates/server-service.yaml
+++ b/dkron/templates/server-service.yaml
@@ -7,6 +7,9 @@ metadata:
 spec:
   type: {{ .Values.server.service.type }}
   clusterIP: None
+  # Servers have to be available even they aren't ready
+  # because they need to join the cluster
+  publishNotReadyAddresses: true
   ports:
     - protocol: TCP
       name: serf

--- a/dkron/templates/server-statefulSet.yaml
+++ b/dkron/templates/server-statefulSet.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     {{- include "dkron.serverLabels" . | nindent 4 }}
 spec:
+  podManagementPolicy: Parallel
   {{- if not .Values.server.autoscaling.enabled }}
   replicas: {{ .Values.server.replicaCount }}
   {{- end }}
@@ -65,6 +66,15 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "dkron.fullname" . }}-envs
+          readinessProbe:
+            httpGet:
+              path: /v1/leader
+              port: 8080
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 5
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
hi, @vcastellm!

It seems that dkron needs some improvements to be usable in kubernetes.
This is one of them (I’ll open an issue about the others in the main repository).
1) I added a readiness probe for the dkron server - we would like to understand whether the node is in the cluster or not.
2) `podManagementPolicy: Parallel` - this is necessary so that the cluster is created even if the readiness probe on the first deployed node does not pass.
3) `publishNotReadyAddresses: true` - so that nodes can communicate for elections

In essence, this is a consul-like approach - [statefulset](https://github.com/hashicorp/consul-k8s/blob/main/charts/consul/templates/server-statefulset.yaml) и [service](https://github.com/hashicorp/consul-k8s/blob/main/charts/consul/templates/server-service.yaml)