### PR TITLE
[BUGFIX] make replicaCount field nested to actually work

### DIFF
--- a/dkron/templates/agent-deployment.yaml
+++ b/dkron/templates/agent-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   {{- end }}
 spec:
   {{- if not .Values.agent.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.agent.replicaCount }}
   {{- end }}
   selector:
     matchLabels:


### PR DESCRIPTION
Issue:

replicaCount of agent didn't actually work because the template no referring to it, instead it expect a global replicaCount which is not exist and not relevant.

So i change the reference to the correct property as it nested inside agent 
