### PR TITLE
add cluster role binding and cluster role and tags

### DIFF
--- a/dkron/templates/agent-deployment.yaml
+++ b/dkron/templates/agent-deployment.yaml
@@ -48,6 +48,9 @@ spec:
               - "--retry-join=\"provider=k8s label_selector=\"\"app.kubernetes.io/instance={{ .Release.Name }}\"\" namespace=\"\"{{ .Release.Namespace }}\"\"\""
               - "--log-level={{ .Values.agent.log.level }}"
               - "--tag=\"agent=true\""
+              {{- range .Values.agent.tags }}
+              - "--tag=\"{{ . }}\""
+              {{- end }}
           ports:
             -   name: serf
                 containerPort: 8946

--- a/dkron/templates/cluster-role-binding.yaml
+++ b/dkron/templates/cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "dkron.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dkron.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "dkron.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io

--- a/dkron/templates/clusterrole.yaml
+++ b/dkron/templates/clusterrole.yaml
@@ -1,0 +1,12 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "dkron.fullname" . }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["list", "patch", "get"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]

--- a/dkron/values.yaml
+++ b/dkron/values.yaml
@@ -81,6 +81,8 @@ agent:
 
   log:
     level: "info"
+    
+  tags:
 
   deploymentAnnotations: {}
 


### PR DESCRIPTION
I added this because I was having trouble running dkron in an EKS cluster.

I added the cluster role and cluster-role binding to get this working.

I also added more tags that can be used in the dkron agent since these may be needed for different configurations